### PR TITLE
[NO-ISSUE] method가 다르고 경로는 같은 경우 처리 추가

### DIFF
--- a/src/types/board.ts
+++ b/src/types/board.ts
@@ -9,6 +9,7 @@ export type getListApiParams = {
     sortAsc: boolean;
     lastArticleId: number;
     limit: number;
+    page: number;
 };
 
 export type getListApiResponse = {

--- a/src/utils/apis/clientFetcher.ts
+++ b/src/utils/apis/clientFetcher.ts
@@ -1,5 +1,5 @@
 import { useAuthStore } from '@/store/authStore';
-import { fetchInstance, publicApis } from './fetchInstance';
+import { fetchInstance, isPublicApi } from './fetchInstance';
 import { FetcherOptions } from '@/types/fetcher';
 
 // 토큰 갱신 중복 방지
@@ -10,8 +10,9 @@ export const clientFetcher = async <TResponse, TRequest>(
     options: FetcherOptions<TRequest> = {}
 ): Promise<TResponse> => {
     const authStore = useAuthStore.getState();
-    const isPublic = publicApis.includes(url);
+    const isPublic = isPublicApi(url, options.method);
     const headers = new Headers(options.headers);
+    console.log('isPublic', isPublic);
     if (!isPublic) {
         const token = authStore.accessToken;
         if (token) {

--- a/src/utils/apis/fetchInstance.ts
+++ b/src/utils/apis/fetchInstance.ts
@@ -2,18 +2,15 @@ import { FetcherOptions } from '@/types/fetcher';
 
 //const baseURL = 'http://localhost:3000';
 export const publicApis: { method: string; path: string }[] = [
-    // 프록시를 통한 인증 관련 API
     { method: 'POST', path: '/api/proxy/login' },
     { method: 'POST', path: '/api/proxy/signup' },
 
-    // 직접 백엔드 호출 인증 API
     { method: 'POST', path: '/api/auth/login' },
     { method: 'POST', path: '/api/auth/signup' },
     { method: 'POST', path: '/api/auth/findpassword' },
 
-    // 게시글 관련 (GET만 public)
     { method: 'GET', path: '/api/board' },
-    { method: 'GET', path: '/api/board/' }, // 특정 게시글 조회용
+    { method: 'GET', path: '/api/board/' },
 ];
 export const internalApis = [
     '/api/proxy/login',
@@ -34,12 +31,9 @@ export const fetchInstance = async <TResponse, TRequest>(
     url: string,
     options: FetcherOptions<TRequest> = {}
 ): Promise<TResponse> => {
-    //const fullUrl = `${baseURL}${url}`;
     let fullUrl: string;
-    //프록시 요청
     const FRONTEND_URL =
         process.env.NEXT_PUBLIC_FRONTEND_URL || 'http://localhost:3000';
-    //실제 api 요청
     const BACKEND_URL =
         process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3000';
     if (isInternalApi(url)) {

--- a/src/utils/apis/getListApi.ts
+++ b/src/utils/apis/getListApi.ts
@@ -16,6 +16,7 @@ export const getListApi = {
             sortAsc: String(params.sortAsc),
             lastArticleId: params.lastArticleId.toString(),
             limit: params.limit.toString(),
+            page: params.page.toString(),
         });
 
         return customFetcher<getListApiResponse, undefined>(


### PR DESCRIPTION
## ❓이슈

- close #이슈번호

## :writing_hand: Description
fetchInstance 에서 publicApis 경로부분에 경로는 같지만 method가 다른 경우의 처리를 추가하였습니다.
ex) /api/board 같은 경우  GET 요청일 때는 액세스토큰 필요하지않지만 POST 경우에는 필요함

<!-- 어떤 내용의 PR인지 작성해주세요. (ex. 메인 페이지 레이아웃 작업) -->
<!-- ⚠️ PR에는 해당 PR의 제목에 해당하는 내용만 들어가 있어야 합니다!  -->

## :white_check_mark: Checklist

### PR

- [x] Branch Convention 확인
    > feature/이슈번호/작업 내용
    > refactor/이슈번호/작업 내용
    > fix/이슈번호/작업 내용
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정 (3명 요청 → 2명 통과)

---

### Additional Notes

<!-- 추가 사항이 있을 경우, Todo list를 작성해주세요. -->

- [x] (없음)
